### PR TITLE
add in GitHub action to build, test and publish docker container images

### DIFF
--- a/.github/workflows/build_test_containers.yml
+++ b/.github/workflows/build_test_containers.yml
@@ -1,0 +1,92 @@
+name: Build, test and publish containers
+
+on:
+  pull_request:
+    branches:
+      -  '*'
+  push:
+    branches:
+      -  '*'
+    tags:
+      - '*'
+
+jobs:
+
+  simulation-tests:
+    name: Build containers and run boptest simulation tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      COMPOSE_PROJECT_NAME: boptest_service
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Build and run stack
+        run: |
+          docker-compose -f docker-compose.yml up --build -d
+
+      - name: dump docker logs
+        uses: jwalton/gh-docker-logs@v1
+
+      - name: Upload test cases to minio
+        run: |
+          docker-compose run --no-deps provision python3 -m boptest_submit ./boptest/testcases/testcase1
+          curl http://localhost/testcases
+
+      - name: Wait for web server
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: "http://localhost/testcases"
+          responseCode: 200
+          timeout: 120000
+          interval: 500
+
+      - name: Run test cases 
+        run: |
+          python --version
+          pip install requests matplotlib numpy pandas
+          PYTHONPATH=$GITHUB_WORKSPACE
+          echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
+          # Storing PYTHONPATH above doesn't work for python so setting it below at run 
+          cd boptest && PYTHONPATH=$PWD python examples/python/testcase1.py 
+
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
+
+#-------------------------  Push to GitHub registry (disabled) -----------------------------
+#
+#      - name: Log in to the GitHub container registry
+#        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GH_REGISTRY }}
+        
+#      - name: Publish docker images to GitHub Registry
+#        if: |
+#          github.ref == 'refs/heads/develop' ||
+#          contains(github.ref, 'refs/tags') 
+#        shell: bash
+#        run: ci/publish_to_github.sh
+
+#------------------  Push to docker hub (disabled) -------------------------------------
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Publish docker images to Docker Hub
+        if: |
+          github.ref == 'refs/heads/develop' ||
+          contains(github.ref, 'refs/tags') 
+        shell: bash
+        run: ci/publish_to_docker.sh

--- a/ci/publish_to_docker.sh
+++ b/ci/publish_to_docker.sh
@@ -1,0 +1,29 @@
+# load .env defines in root of repo
+export $(egrep -v '^#' .env | xargs)
+export DOCKER_HUB_WEB_REGISTRY_URI=NREL/boptest-web
+export DOCKER_HUB_WORKER_REGISTRY_URI=NREL/boptest-worker
+
+if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
+    export VERSION_TAG="develop"
+    echo "The docker tag is set to: ${VERSION_TAG}"
+elif [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9].* ]]; then
+    export VERSION_TAG="${GITHUB_REF/refs\/tags\//}"
+    echo "The docker tag is set to: ${VERSION_TAG}"
+# uncomment conditional below if you want to build a custom branch
+# elif [[] "${GITHUB_REF}" == "refs/heads/boptest-service-custom" ]]; then
+#     export VERSION_TAG="experimental"
+fi
+
+ if [[ "${VERSION_TAG}" == "develop" ]] || [[ "${VERSION_TAG}" =~ ^v[0-9].* ]] || [[ "${VERSION_TAG}" == "experimental" ]] ; then
+
+    docker tag ${WEB_REGISTRY_URI}:latest ${DOCKER_HUB_WEB_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+    docker tag ${WORKER_REGISTRY_URI}:latest ${DOCKER_HUB_WORKER_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+
+    echo "pushing ${DOCKER_HUB_WEB_REGISTRY_URI}:${VERSION_TAG}"
+    docker push ${DOCKER_HUB_WEB_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+    echo "pushing ${DOCKER_HUB_WORKER_REGISTRY_URI}:${VERSION_TAG}"
+    docker push ${DOCKER_HUB_WORKER_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+
+fi
+
+exit $exit_status

--- a/ci/publish_to_github.sh
+++ b/ci/publish_to_github.sh
@@ -1,0 +1,29 @@
+# load .env defines in root of repo 
+export $(egrep -v '^#' .env | xargs)
+export GITHUB_WEB_REGISTRY_URI=ghcr.io/NREL/boptest-web
+export GITHUB_WORKER_REGISTRY_URI=ghcr.io/NREL/boptest-worker
+
+if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
+    export VERSION_TAG="develop"
+    echo "The docker tag is set to: ${VERSION_TAG}"
+elif [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9].* ]]; then
+    export VERSION_TAG="${GITHUB_REF/refs\/tags\//}"
+    echo "The docker tag is set to: ${VERSION_TAG}"
+# use conditional below if you want to build a custom branch
+# elif [[] "${GITHUB_REF}" == "refs/heads/boptest-service-custom" ]]; then 
+#     export VERSION_TAG="experimental"
+fi
+
+ if [[ "${VERSION_TAG}" == "develop" ]] || [[ "${VERSION_TAG}" =~ ^v[0-9].* ]] || [[ "${VERSION_TAG}" == "experimental" ]] ; then
+
+    docker tag ${WEB_REGISTRY_URI}:latest ${GITHUB_WEB_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+    docker tag ${WORKER_REGISTRY_URI}:latest ${GITHUB_WORKER_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+
+    echo "pushing ${GITHUB_WEB_REGISTRY_URI}:${VERSION_TAG}"
+    docker push ${GITHUB_WEB_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+    echo "pushing ${GITHUB_WORKER_REGISTRY_URI}:${VERSION_TAG}"
+    docker push ${GITHUB_WORKER_REGISTRY_URI}:${VERSION_TAG}; (( exit_status = exit_status || $? ))
+
+fi
+
+exit $exit_status


### PR DESCRIPTION
resolves #12 

Adding in a GitHub Action to build, test and publish the worker and web containers. Images will be tagged using the version scheme in this rep (e.g. nrel/boptest-worker:v0.1.0). The boptest library will be maintained in the https://github.com/ibpsa/project1-boptest and will have its own version. 

Merges to develop to will build images and tag as "develop" e.g. nrel/boptest-worker:develop, while tagged commits will build and push as the tag name (e.g. nrel/boptest-worker:v0.1.0). 

