### PR TITLE
Pass authorization to _wait_for_testcase

### DIFF
--- a/provision/boptest_submit/boptest_submit.py
+++ b/provision/boptest_submit/boptest_submit.py
@@ -68,22 +68,26 @@ class BoptestSubmit:
                 return False
 
             # Confirm that the testcase exists
-            self._wait_for_testcase(testcaseid)
+            self._wait_for_testcase(testcaseid, shared, auth_token)
 
             return testcaseid
         except:
             return False
 
-    def _exists(self, testcaseid):
-        url = '{}/testcases/{}'.format(self.server, testcaseid)
-        response = requests.get(url)
+    def _exists(self, testcaseid, shared, auth_token):
+        if shared:
+          url = '{}/testcases/{}'.format(self.server, testcaseid)
+          response = requests.get(url)
+        else:   
+          url = '{}/my/testcases/{}'.format(self.server, testcaseid)
+          response = requests.get(url, headers={'Authorization': auth_token})   
         return response.ok
 
-    def _wait_for_testcase(self, testcaseid):
+    def _wait_for_testcase(self, testcaseid, shared, auth_token):
         attempts = 0
         while attempts < 6000:
             attempts = attempts + 1
-            if self._exists(testcaseid):
+            if self._exists(testcaseid, shared, auth_token):
                 break
             time.sleep(2)
 


### PR DESCRIPTION
The GET `/my/testcases/` in `_wait_for_testcase` would not work without authorization, because it is an authorized route. This could be a way to fix it. 