### PR TITLE
K8s pod deletion cost

### DIFF
--- a/worker/requirements/production.txt
+++ b/worker/requirements/production.txt
@@ -31,3 +31,4 @@ wheel==0.34.2
 zipp==1.0.0
 flask==1.1.2
 msgpack==1.0.4
+kubernetes==25.3.0

--- a/worker/requirements/production.txt
+++ b/worker/requirements/production.txt
@@ -18,7 +18,7 @@ pandas==0.24.2
 pymongo==3.10.1
 python-dateutil==2.8.1
 pytz==2019.3
-PyYAML==5.3
+PyYAML==5.4.1
 redis==3.3.11
 requests==2.22.0
 s3transfer==0.3.0
@@ -31,4 +31,4 @@ wheel==0.34.2
 zipp==1.0.0
 flask==1.1.2
 msgpack==1.0.4
-kubernetes==25.3.0
+kubernetes==18.20.0

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -33,6 +33,7 @@ import sys
 from datetime import datetime
 import boto3
 from .logger import Logger
+from kubernetes import client, config
 
 class Worker:
     """The main Worker class.  Used for processing messages from the boto3 SQS Queue resource"""
@@ -42,6 +43,7 @@ class Worker:
         self.sqs = boto3.resource('sqs', region_name=os.environ['REGION'], endpoint_url=os.environ['JOB_QUEUE_URL'])
         self.sqs_queue = self.sqs.Queue(url=os.environ['JOB_QUEUE_URL'])
         self.logger.info("Worker initialized")
+  
 
     def process_message(self, message):
         """
@@ -55,6 +57,24 @@ class Worker:
         jobtype = message_body.get('jobtype')
         params = message_body.get('params')
         subprocess.call(['python', '-m', jobtype, json.dumps(params)])
+    
+    def _update_k8s(self, pod_deletion_cost):
+        """
+        Update k8s pod status when job is running. This is to prevent a pod from being 
+        terminated during the downscale that is still processing a job.
+
+        :param pod_deletion_cost:  String that represents the cost of deleting a 
+        pod compared to other pods belonging to the same Deployment/Replicaset. e.g. "10". 
+        :return:
+        """
+        try:
+            config.load_incluster_config()
+            v1 = client.CoreV1Api()
+            pod = v1.read_namespaced_pod(name=os.environ['HOSTNAME'], namespace="default")
+            pod.metadata.annotations["controller.kubernetes.io/pod-deletion-cost"] = pod_deletion_cost
+            v1.patch_namespaced_pod(name=os.environ['HOSTNAME'], namespace="default", body=pod)
+        except BaseException as e:
+                self.logger.info("Exception while updating k8s pod worker annotation {}".format(e))
 
     def run(self):
         """
@@ -63,13 +83,23 @@ class Worker:
         :return:
         """
         self.logger.info("Worker running")
+    
         while True:
             try:
+               
                 # WaitTimeSeconds triggers long polling that will wait for events to enter queue
                 messages = self.sqs_queue.receive_messages(MaxNumberOfMessages=1, WaitTimeSeconds=20)
                 if len(messages) > 0:
                     message = messages[0]
                     self.logger.info('Message Received with payload: %s' % message.body)
-                    self.process_message(message)
+                    # Check if running environment is in k8s and update pod status if true
+                    if os.environ['K8S_ENVIRONMENT']:
+                        self._update_k8s("99")
+                        self.process_message(message)
+                        self._update_k8s("0")
+                    else: 
+                        self.process_message(message)
+                       
+                        
             except BaseException as e:
                 self.logger.info("Exception while processing messages in worker: {}".format(e))


### PR DESCRIPTION
This allows the worker to set a k8s pod annotation "pod_cost" which the k8s controller uses to determine which pods to terminate during a downscale operation. This reduces (maybe eliminates) the risk associated with k8s controller terminating pods that have active jobs during downscale.  



