### PR TITLE
lower case for registry name for docker hub

### DIFF
--- a/ci/publish_to_docker.sh
+++ b/ci/publish_to_docker.sh
@@ -1,7 +1,7 @@
 # load .env defines in root of repo
 export $(egrep -v '^#' .env | xargs)
-export DOCKER_HUB_WEB_REGISTRY_URI=NREL/boptest-web
-export DOCKER_HUB_WORKER_REGISTRY_URI=NREL/boptest-worker
+export DOCKER_HUB_WEB_REGISTRY_URI=nrel/boptest-web
+export DOCKER_HUB_WORKER_REGISTRY_URI=nrel/boptest-worker
 
 if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
     export VERSION_TAG="develop"


### PR DESCRIPTION
Docker Hub is complaining that the org name NREL is uppercase on push.  Changing to lowercase.  This was tested on my fork NREL https://github.com/tijcolem/boptest-service but I was pushing to a different docker hub registry 'tijcolem' to test. 

