### PR TITLE
Allow test cases and simulation results to be downloaded

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,11 @@ services:
       - minio
       - server
       - /data
+      - --console-address
+      - ":9001"
     ports:
       - "9000:9000"
+      - "9001:9001"
     environment:
       - MINIO_ACCESS_KEY=${AWS_ACCESS_KEY_ID}
       - MINIO_SECRET_KEY=${AWS_SECRET_ACCESS_KEY}

--- a/web/server/src/lib/boptestLib.js
+++ b/web/server/src/lib/boptestLib.js
@@ -65,14 +65,19 @@ function promiseTaskLater(task, time, ...args) {
   })
 }
 
-export function getTestcasePostForm(testcaseKey, s3url) {
+export function getTestcasePostForm(testcaseKey, s3url, share) {
   return new Promise((resolve, reject) => {
     // Construct a new postPolicy.
-    const params = {
+    let params = {
       Bucket: bucket,
       Fields: {
         key: testcaseKey
       }
+    }
+
+    if (share) {
+      // minio does not support object level ACL, therefore ExtraArgs will only apply to s3 configurations
+      params.Fields.acl = "public-read"
     }
     
     s3.createPresignedPost(params, function(err, data) {

--- a/web/server/src/routes/boptestRoutes.js
+++ b/web/server/src/routes/boptestRoutes.js
@@ -25,7 +25,7 @@ boptestRoutes.get('/version', async (req, res, next) => {
 // GET test case post-form //
 
 const getTestcasePostForm = async (req, res, next) => {
-  res.json(await boptestLib.getTestcasePostForm(req.testcaseKey, s3PublicURL))
+  res.json(await boptestLib.getTestcasePostForm(req.testcaseKey, s3PublicURL, req.share))
 }
 
 boptestRoutes.get('/testcases/:testcaseID/post-form',
@@ -33,6 +33,7 @@ boptestRoutes.get('/testcases/:testcaseID/post-form',
   middleware.requireSuperUser,
   (req, res, next) => {
     req.testcaseKey = boptestLib.getKeyForTestcase(ibpsaNamespace, req.params.testcaseID)
+    req.share = true
     next()
   },
   getTestcasePostForm
@@ -43,6 +44,7 @@ boptestRoutes.get('/testcases/:testcaseNamespace/:testcaseID/post-form',
   middleware.requireSuperUser,
   (req, res, next) => {
     req.testcaseKey = boptestLib.getKeyForTestcase(req.params.testcaseNamespace, req.params.testcaseID)
+    req.share = true
     next()
   },
   getTestcasePostForm
@@ -53,6 +55,7 @@ boptestRoutes.get('/users/:userName/testcases/:testcaseID/post-form',
   middleware.requireUser,
   (req, res, next) => {
     req.testcaseKey = boptestLib.getKeyForUserTestcase(req.account.dis, req.params.testcaseID)
+    req.share = false
     next()
   },
   getTestcasePostForm

--- a/worker/jobs/boptest_run_test/job.py
+++ b/worker/jobs/boptest_run_test/job.py
@@ -260,7 +260,8 @@ class Job:
         tar.close()
 
         uploadkey = "simulated/%s" % tarname
-        self.s3_bucket.upload_file(tarname, uploadkey)
+        # minio does not support object level ACL, therefore ExtraArgs will only apply to s3 configurations
+        self.s3_bucket.upload_file(tarname, uploadkey, ExtraArgs={'ACL': 'public-read'})
         os.remove(tarname)
 
         shutil.rmtree(self.test_dir)


### PR DESCRIPTION
This change enables the minio console on port 9001 for local `docker compose` based development. There is also a change to set the ACL to public-read for simulation results and namespaced test cases. User specific test cases are still private.

close #28