### PR TITLE
Pin `worker/Dockerfile` image to `linux/x86_64`

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/x86_64 ubuntu:20.04
 
 USER root
 ENV HOME /home/boptest


### PR DESCRIPTION
Pin the `worker/Docker` image to `linux/x86_64` to enable the image to be used on Apple Silicon machines easily. This is similar to https://github.com/ibpsa/project1-boptest/pull/607 in the BOPTEST repo.

Error for future reference:
```
$ docker compose up web worker provision
...
1.830 2024-02-16 22:56:56 (47.1 MB/s) - '/miniconda.sh' saved [74403966/74403966]
1.830
1.836 PREFIX=/miniconda
2.063 Unpacking payload ...
2.069 rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
2.069  /miniconda.sh: line 352:    38 Exit 141                extract_range $boundary1 $boundary2
2.069         39 Trace/breakpoint trap   | "$CONDA_EXEC" constructor --extract-tarball --prefix "$PREFIX"
------
failed to solve: process "/bin/sh -c wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -O /miniconda.sh \t&& /bin/bash /miniconda.sh -b -p /miniconda \t&& . miniconda/bin/activate \t&& conda update -n base -c defaults conda \t&& conda create --name pyfmi3 python=3.10 -y \t&& conda activate pyfmi3 \t&& conda install -c conda-forge pyfmi=2.11 -y \t&& pip install -U pip setuptools   && python -m pip install --ignore-installed -r /boptest/production.txt   && conda install pandas==1.5.3" did not complete successfully: exit code: 133
```

The conda binary is already pinned to x86_64 so this just goes one step further with the base image:

https://github.com/NREL/boptest-service/blob/08135ab6a9f3757687264dd5273c1fe539d29a24/worker/Dockerfile#L21